### PR TITLE
feat(client): auto fetch max number of players

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -5,11 +5,12 @@ Citizen.CreateThread(function()
         local OnlinePlayers = GetActivePlayers()
         local id = GetPlayerServerId(PlayerId())
         local Player = GetPlayerName(PlayerId())
+        local maxPlayers = GetConvarInt("sv_maxclients", 48)
 
         local template = Config.Text
 
         local replacements = {
-            ["{Players}"] = #OnlinePlayers .. "/" ..Config.ServerSlots,
+            ["{Players}"] = #OnlinePlayers .. "/" ..maxPlayers,
             ["{ID}"] = id,
             ["{PlayerName}"] = Player,
         }

--- a/server/updater.lua
+++ b/server/updater.lua
@@ -1,3 +1,5 @@
+SetConvarReplicated("sv_maxclients", "true")
+
 if Config.UpdateCheck then
     
     CreateThread(function()

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -2,7 +2,6 @@ Config = {
 
     ApplicationID = 1193592918515138732,
     UpdateTime = 60, -- In Seconds
-    ServerSlots = 48,
     UpdateCheck = true,
 
 


### PR DESCRIPTION
fetch max number of players automatically without having to manually configure, not tested but should work as intended